### PR TITLE
Fix periode: Grunnlagresult verneplikt has identificator "Verneplikt"…

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/Periode.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/Periode.kt
@@ -100,12 +100,12 @@ fun mapEvalureringResultatToInt(it: Evaluering): List<Int> {
 
 fun finnHøyestePeriodeFraEvaluering(evaluering: Evaluering, fakta: Fakta): Int? {
 
-    if (fakta.grunnlagBeregningsregel == "VERNEPLIKT") {
-        return 26
+    return if (fakta.grunnlagBeregningsregel == "Verneplikt") {
+        26
     } else {
         val periodeResultat: Int? =
             evaluering.children.filter { it.resultat == Resultat.JA }.flatMap { mapEvalureringResultatToInt(it) }.max()
-        return periodeResultat
+        periodeResultat
     }
 }
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
@@ -22,7 +22,7 @@ class FinnerRettPeriodeTest {
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false,
-            grunnlagBeregningsregel = "VERNEPLIKT")
+            grunnlagBeregningsregel = "Verneplikt")
 
         val resultat = periode.evaluer(fakta)
 


### PR DESCRIPTION
… not "VERNEPLIKT"


See https://github.com/navikt/dp-regel-grunnlag/blob/master/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/DagpengerEtterAvtjentVerneplikt.kt#L7 