### PR TITLE
- 'sisteAvsluttendeKalenderMåned' is part of inntekt response, replac…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ val orgJsonVersion = "20180813"
 dependencies {
     implementation(kotlin("stdlib"))
     implementation("com.github.navikt:dagpenger-streams:2019.05.21-14.30.a7af5e9d49fe")
-    implementation("com.github.navikt:dagpenger-events:2019.05.20-11.56.33cd4c73a439")
+    implementation("com.github.navikt:dagpenger-events:2019.05.28-13.44.ab5008b3ee50")
 
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
 

--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/Fakta.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/Fakta.kt
@@ -5,11 +5,9 @@ import no.nav.dagpenger.events.inntekt.v1.InntektKlasse
 import no.nav.dagpenger.events.inntekt.v1.all
 import no.nav.dagpenger.events.inntekt.v1.sumInntekt
 import java.math.BigDecimal
-import java.time.YearMonth
 
 data class Fakta(
     val inntekt: Inntekt,
-    val senesteInntektsmåned: YearMonth,
     val bruktInntektsPeriode: InntektsPeriode? = null,
     val verneplikt: Boolean,
     val fangstOgFisk: Boolean,
@@ -19,7 +17,7 @@ data class Fakta(
 
     val filtrertInntekt = bruktInntektsPeriode?.let { inntektsPeriode -> inntekt.filterPeriod(inntektsPeriode.førsteMåned, inntektsPeriode.sisteMåned) } ?: inntekt
 
-    val splitInntekt = filtrertInntekt.splitIntoInntektsPerioder(senesteInntektsmåned)
+    val splitInntekt = filtrertInntekt.splitIntoInntektsPerioder()
 
     val arbeidsinntektSiste12 = splitInntekt.first.sumInntekt(listOf(InntektKlasse.ARBEIDSINNTEKT))
     val arbeidsinntektSiste36 = splitInntekt.all().sumInntekt(listOf(InntektKlasse.ARBEIDSINNTEKT))

--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/PacketToFakta.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/PacketToFakta.kt
@@ -2,7 +2,6 @@ package no.nav.dagpenger.regel.periode
 
 import no.nav.dagpenger.events.Packet
 import no.nav.dagpenger.events.inntekt.v1.Inntekt
-import java.time.YearMonth
 
 private val inntektAdapter =
     moshiInstance.adapter<no.nav.dagpenger.events.inntekt.v1.Inntekt>(no.nav.dagpenger.events.inntekt.v1.Inntekt::class.java)
@@ -12,7 +11,6 @@ private val bruktInntektsPeriodeAdapter = moshiInstance.adapter<InntektsPeriode>
 internal fun packetToFakta(packet: Packet): Fakta {
     val verneplikt = packet.getNullableBoolean(Periode.AVTJENT_VERNEPLIKT) ?: false
     val inntekt: Inntekt = packet.getObjectValue(Periode.INNTEKT) { inntektAdapter.fromJsonValue(it)!! }
-    val senesteInntektsmåned = YearMonth.parse(packet.getStringValue(Periode.SENESTE_INNTEKTSMÅNED))
 
     val bruktInntektsPeriode =
         packet.getNullableObjectValue(Periode.BRUKT_INNTEKTSPERIODE, bruktInntektsPeriodeAdapter::fromJsonValue)
@@ -23,7 +21,6 @@ internal fun packetToFakta(packet: Packet): Fakta {
 
     return Fakta(
         inntekt,
-        senesteInntektsmåned,
         bruktInntektsPeriode,
         verneplikt,
         fangstOgFisk,

--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/Periode.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/Periode.kt
@@ -29,7 +29,6 @@ class Periode(private val env: Environment) : River() {
         val INNTEKT = "inntektV1"
         val AVTJENT_VERNEPLIKT = "harAvtjentVerneplikt"
         val FANGST_OG_FISK = "oppfyllerKravTilFangstOgFisk"
-        val SENESTE_INNTEKTSMÅNED = "senesteInntektsmåned"
         val BRUKT_INNTEKTSPERIODE = "bruktInntektsPeriode"
         val GRUNNLAG_RESULTAT = "grunnlagResultat"
         val BEREGNINGS_REGEL_GRUNNLAG = "beregningsregel"
@@ -38,7 +37,6 @@ class Periode(private val env: Environment) : River() {
     override fun filterPredicates(): List<Predicate<String, Packet>> {
         return listOf(
             Predicate { _, packet -> packet.hasField(INNTEKT) },
-            Predicate { _, packet -> packet.hasField(SENESTE_INNTEKTSMÅNED) },
             Predicate { _, packet -> packet.hasField(GRUNNLAG_RESULTAT) },
             Predicate { _, packet -> !packet.hasField(PERIODE_RESULTAT) })
     }

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
@@ -14,15 +14,20 @@ class FinnerRettPeriodeTest {
     @Test
     fun ` Skal returnere 26 uker periode dersom beregningsregelen fra grunnlag er verneplikt `() {
 
+        val inntektsListe = generateArbeidsInntekt(
+            1..12, BigDecimal(3000)
+        )
         val fakta = Fakta(
             inntekt = Inntekt(
                 "123",
-                generateArbeidsInntekt(1..12, BigDecimal(3000))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+                inntektsListe, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+
+            ),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false,
-            grunnlagBeregningsregel = "Verneplikt")
+            grunnlagBeregningsregel = "Verneplikt"
+        )
 
         val resultat = periode.evaluer(fakta)
 
@@ -32,15 +37,18 @@ class FinnerRettPeriodeTest {
     @Test
     fun ` Skal returnere 52 uker periode dersom beregningsregelen fra grunnlag er ikke er verneplikt og har tjent mindre enn 2G `() {
 
+        val inntektsListe = generateArbeidsInntekt(1..12, BigDecimal(3000))
         val fakta = Fakta(
             inntekt = Inntekt(
                 "123",
-                generateArbeidsInntekt(1..12, BigDecimal(3000))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+                inntektsListe,
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false,
-            grunnlagBeregningsregel = "BLA")
+            grunnlagBeregningsregel = "BLA"
+        )
 
         val resultat = periode.evaluer(fakta)
 
@@ -50,15 +58,18 @@ class FinnerRettPeriodeTest {
     @Test
     fun ` Skal returnere 104 uker periode dersom beregningsregelen fra grunnlag er ikke er verneplikt og har tjent mer enn 2G `() {
 
+        val inntektsListe = generateArbeidsInntekt(1..12, BigDecimal(30000))
         val fakta = Fakta(
             inntekt = Inntekt(
                 "123",
-                generateArbeidsInntekt(1..12, BigDecimal(30000))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+                inntektsListe,
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false,
-            grunnlagBeregningsregel = "BLA")
+            grunnlagBeregningsregel = "BLA"
+        )
 
         val resultat = periode.evaluer(fakta)
 
@@ -70,8 +81,10 @@ class FinnerRettPeriodeTest {
             KlassifisertInntektMåned(
                 YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
                     KlassifisertInntekt(
-                        beløpPerMnd, InntektKlasse.ARBEIDSINNTEKT)
-                ))
+                        beløpPerMnd, InntektKlasse.ARBEIDSINNTEKT
+                    )
+                )
+            )
         }
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PacketToFaktaTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PacketToFaktaTest.kt
@@ -11,7 +11,8 @@ class PacketToFaktaTest {
 
     val emptyInntekt: Inntekt = Inntekt(
         inntektsId = "12345",
-        inntektsListe = emptyList()
+        inntektsListe = emptyList(),
+        sisteAvsluttendeKalenderMåned = YearMonth.of(2018, 3)
     )
 
     val jsonAdapterInntekt = moshiInstance.adapter(Inntekt::class.java)
@@ -20,7 +21,6 @@ class PacketToFaktaTest {
     fun ` should map fangst_og_fisk from packet to Fakta `() {
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "grunnlagResultat":{"beregningsregel": "test"},
             "oppfyllerKravTilFangstOgFisk": true
         }""".trimIndent()
@@ -37,7 +37,6 @@ class PacketToFaktaTest {
     fun ` should map avtjent_verneplikt from packet to Fakta `() {
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "grunnlagResultat":{"beregningsregel": "test"},
             "harAvtjentVerneplikt": true
         }""".trimIndent()
@@ -54,7 +53,6 @@ class PacketToFaktaTest {
     fun ` should map brukt_inntektsperiode from packet to Fakta `() {
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "grunnlagResultat":{"beregningsregel": "test"},
             "bruktInntektsPeriode": {"førsteMåned":"2019-02", "sisteMåned":"2019-03"}
         }""".trimIndent()
@@ -72,7 +70,6 @@ class PacketToFaktaTest {
     fun ` should map inntekt from packet to Fakta `() {
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "grunnlagResultat":{"beregningsregel": "test"}
         }""".trimIndent()
 
@@ -85,26 +82,9 @@ class PacketToFaktaTest {
     }
 
     @Test
-    fun ` should map seneste_inntektsmåned from packet to Fakta `() {
-        val json = """
-        {
-            "senesteInntektsmåned":"2018-03",
-            "grunnlagResultat":{"beregningsregel": "test"}
-        }""".trimIndent()
-
-        val packet = Packet(json)
-        packet.putValue("inntektV1", jsonAdapterInntekt.toJsonValue(emptyInntekt)!!)
-
-        val fakta = packetToFakta(packet)
-
-        assertEquals(YearMonth.of(2018, 3), fakta.senesteInntektsmåned)
-    }
-
-    @Test
     fun ` should map grunnlag_beregningsregel from packet to Fakta `() {
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "grunnlagResultat":{"beregningsregel": "regel"}
         }""".trimIndent()
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/Periode104UkerTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/Periode104UkerTest.kt
@@ -15,12 +15,17 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal gi periode på 104 uker når man har arbeidsinntekt over 2 G siste 12 mnd`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generate12MånederArbeidsInntekt()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generate12MånederArbeidsInntekt(),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
-            grunnlagBeregningsregel = "bla")
+            grunnlagBeregningsregel = "bla"
+        )
 
         val evaluering = ordinærSiste12Måneder104Uker.evaluer(fakta)
 
@@ -30,12 +35,17 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal gi periode på 104 uker når man har næringsinntekt over 2 G siste 12 mnd og fangst og fisk er oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generate12MånederFangstOgFiskInntekt()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generate12MånederFangstOgFiskInntekt(),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = true,
-            grunnlagBeregningsregel = "bla")
+            grunnlagBeregningsregel = "bla"
+        )
 
         val evaluering = ordinærSiste12MånederMedFangstOgFiske104Uker.evaluer(fakta)
 
@@ -45,12 +55,17 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal gi periode på 104 uker når man har arbeidsinntekt over 2 G i snitt de siste 36 mnd`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generate36MånederArbeidsInntekt()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generate36MånederArbeidsInntekt(),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
-            grunnlagBeregningsregel = "bla")
+            grunnlagBeregningsregel = "bla"
+        )
 
         val evaluering = ordinærSiste36Måneder104Uker.evaluer(fakta)
 
@@ -60,12 +75,17 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal gi periode på 104 uker når man har næringsinntekt over 2 G i snitt de siste 36 mnd og fangst og fisk er oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generate36MånederFangstOgFiskInntekt()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generate36MånederFangstOgFiskInntekt(),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = true,
-            grunnlagBeregningsregel = "bla")
+            grunnlagBeregningsregel = "bla"
+        )
 
         val evaluering = ordinærSiste36MånederMedFangstOgFiske104Uker.evaluer(fakta)
 
@@ -75,8 +95,12 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal ikke gi periode på 104 uker når man har arbeidsinntekt under 2 G siste 12 mnd`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateArbeidsInntekt(1..12, BigDecimal(1))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateArbeidsInntekt(1..12, BigDecimal(1)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
@@ -92,8 +116,12 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal ikke gi periode på 104 uker når man har næringsinntektinntekt under 2 G siste 12 mnd og fangst og fisk er oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateFangstOgFiskInntekt(1..12, BigDecimal(1))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateFangstOgFiskInntekt(1..12, BigDecimal(1)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = true,
@@ -109,8 +137,12 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal ikke gi periode på 104 uker når man har arbeidsinntekt under 2 G i snitt de siste 36 mnd`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateArbeidsInntekt(1..36, BigDecimal(1))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateArbeidsInntekt(1..36, BigDecimal(1)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
@@ -126,8 +158,12 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal ikke gi periode på 104 uker når man har næringsinntekt under 2 G i snitt de siste 36 mnd og fangst og fisk er oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateFangstOgFiskInntekt(1..36, BigDecimal(1))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateFangstOgFiskInntekt(1..36, BigDecimal(1)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = true,
@@ -143,8 +179,12 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal ikke gi periode på 104 uker når man har næringsinntektinntekt over 2 G siste 12 mnd men fangst og fisk er ikke oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generate12MånederFangstOgFiskInntekt()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generate12MånederFangstOgFiskInntekt(),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
@@ -160,8 +200,12 @@ internal class Periode104UkerTest {
     @Test
     fun `Skal ikke gi periode på 104 uker når man har næringsinntektinntekt over 2 G i snitt de siste 36 mnd men fangst og fisk er ikke oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generate36MånederFangstOgFiskInntekt()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generate36MånederFangstOgFiskInntekt(),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
@@ -176,10 +220,13 @@ internal class Periode104UkerTest {
 
     fun generateArbeidsInntekt(range: IntRange, beløpPerMnd: BigDecimal): List<KlassifisertInntektMåned> {
         return (range).toList().map {
-            KlassifisertInntektMåned(YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
-                KlassifisertInntekt(
-                    beløpPerMnd, InntektKlasse.ARBEIDSINNTEKT)
-            ))
+            KlassifisertInntektMåned(
+                YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
+                    KlassifisertInntekt(
+                        beløpPerMnd, InntektKlasse.ARBEIDSINNTEKT
+                    )
+                )
+            )
         }
     }
 
@@ -193,10 +240,13 @@ internal class Periode104UkerTest {
 
     fun generateFangstOgFiskInntekt(range: IntRange, beløpPerMnd: BigDecimal): List<KlassifisertInntektMåned> {
         return (range).toList().map {
-            KlassifisertInntektMåned(YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
-                KlassifisertInntekt(
-                    beløpPerMnd, InntektKlasse.FANGST_FISKE)
-            ))
+            KlassifisertInntektMåned(
+                YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
+                    KlassifisertInntekt(
+                        beløpPerMnd, InntektKlasse.FANGST_FISKE
+                    )
+                )
+            )
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/Periode52UkerTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/Periode52UkerTest.kt
@@ -15,12 +15,17 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal ikke gi periode på 52 uker når man har arbeidsinntekt over 2 G siste 12 mnd`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateArbeidsInntekt(1..12, BigDecimal(50000))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateArbeidsInntekt(1..12, BigDecimal(50000)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
-            grunnlagBeregningsregel = "bla")
+            grunnlagBeregningsregel = "bla"
+        )
 
         val evaluering = ordinærSiste12Måneder52Uker.evaluer(fakta)
 
@@ -30,12 +35,17 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal ikke gi periode på 52 uker når man har næringsinntekt over 2 G siste 12 mnd og fangst og fisk er oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateFangstOgFiskInntekt(1..12, BigDecimal(50000))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateFangstOgFiskInntekt(1..12, BigDecimal(50000)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = true,
-            grunnlagBeregningsregel = "bla")
+            grunnlagBeregningsregel = "bla"
+        )
 
         val evaluering = ordinærSiste12MånederMedFangstOgFiske52Uker.evaluer(fakta)
 
@@ -45,12 +55,17 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal ikke gi periode på 52 uker når man har arbeidsinntekt over 2 G i snitt de siste 36 mnd`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateArbeidsInntekt(1..36, BigDecimal(50000))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateArbeidsInntekt(1..36, BigDecimal(50000)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
-            grunnlagBeregningsregel = "bla")
+            grunnlagBeregningsregel = "bla"
+        )
 
         val evaluering = ordinærSiste36Måneder52Uker.evaluer(fakta)
 
@@ -60,12 +75,17 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal ikke gi periode på 52 uker når man har næringsinntekt over 2 G i snitt de siste 36 mnd og fangst og fisk er oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateFangstOgFiskInntekt(1..12, BigDecimal(50000))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateFangstOgFiskInntekt(1..12, BigDecimal(50000)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = true,
-            grunnlagBeregningsregel = "bla")
+            grunnlagBeregningsregel = "bla"
+        )
 
         val evaluering = ordinærSiste36MånederMedFangstOgFiske52Uker.evaluer(fakta)
 
@@ -75,8 +95,12 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal gi periode på 52 uker når man har arbeidsinntekt under 2 G siste 12 mnd`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateArbeidsInntekt(1..12, BigDecimal(1))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateArbeidsInntekt(1..12, BigDecimal(1)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
@@ -92,8 +116,12 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal gi periode på 52 uker når man har næringsinntektinntekt under 2 G siste 12 mnd og fangst og fisk er oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateFangstOgFiskInntekt(1..12, BigDecimal(1))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateFangstOgFiskInntekt(1..12, BigDecimal(1)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = true,
@@ -109,8 +137,12 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal gi periode på 52 uker når man har arbeidsinntekt under 2 G i snitt de siste 36 mnd`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateArbeidsInntekt(1..36, BigDecimal(1))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateArbeidsInntekt(1..36, BigDecimal(1)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
@@ -126,8 +158,12 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal gi periode på 52 uker når man har næringsinntekt under 2 G i snitt de siste 36 mnd og fangst og fisk er oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generateFangstOgFiskInntekt(1..36, BigDecimal(1))),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generateFangstOgFiskInntekt(1..36, BigDecimal(1)),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = true,
@@ -143,8 +179,12 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal ikke gi periode på 52 uker når man har næringsinntektinntekt over 2 G siste 12 mnd men fangst og fisk er ikke oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generate12MånederFangstOgFiskInntekt()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generate12MånederFangstOgFiskInntekt(),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
@@ -160,8 +200,12 @@ internal class Periode52UkerTest {
     @Test
     fun `Skal ikke gi periode på 52 uker når man har næringsinntektinntekt over 2 G i snitt de siste 36 mnd men fangst og fisk er ikke oppfylt`() {
 
-        val fakta = Fakta(inntekt = Inntekt("123", generate36MånederFangstOgFiskInntekt()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+        val fakta = Fakta(
+            inntekt = Inntekt(
+                "123",
+                generate36MånederFangstOgFiskInntekt(),
+                sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)
+            ),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
@@ -176,19 +220,25 @@ internal class Periode52UkerTest {
 
     fun generateArbeidsInntekt(range: IntRange, beløpPerMnd: BigDecimal): List<KlassifisertInntektMåned> {
         return (range).toList().map {
-            KlassifisertInntektMåned(YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
-                KlassifisertInntekt(
-                    beløpPerMnd, InntektKlasse.ARBEIDSINNTEKT)
-            ))
+            KlassifisertInntektMåned(
+                YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
+                    KlassifisertInntekt(
+                        beløpPerMnd, InntektKlasse.ARBEIDSINNTEKT
+                    )
+                )
+            )
         }
     }
 
     fun generateFangstOgFiskInntekt(range: IntRange, beløpPerMnd: BigDecimal): List<KlassifisertInntektMåned> {
         return (range).toList().map {
-            KlassifisertInntektMåned(YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
-                KlassifisertInntekt(
-                    beløpPerMnd, InntektKlasse.FANGST_FISKE)
-            ))
+            KlassifisertInntektMåned(
+                YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
+                    KlassifisertInntekt(
+                        beløpPerMnd, InntektKlasse.FANGST_FISKE
+                    )
+                )
+            )
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeEtterAvtjentVernepliktTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeEtterAvtjentVernepliktTest.kt
@@ -13,8 +13,7 @@ internal class PeriodeEtterAvtjentVernepliktTest {
 
         // gitt fakta
         val fakta = Fakta(
-            inntekt = Inntekt("123", emptyList()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false,
@@ -33,8 +32,7 @@ internal class PeriodeEtterAvtjentVernepliktTest {
 
         // gitt fakta
         val fakta = Fakta(
-            inntekt = Inntekt("123", emptyList()),
-            senesteInntektsmåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeSpesifikasjonerTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeSpesifikasjonerTest.kt
@@ -11,12 +11,16 @@ internal class PeriodeSpesifikasjonerTest {
 
     @Test
     fun `Periode består av ordinær`() {
-        assertEquals("ORDINÆR_12_52, , ORDINÆR_36_52, , ORDINÆR_12_52_FANGSTOGFISK, , ORDINÆR_36_52_FANGSTOGFISK, , ORDINÆR_12_104, , ORDINÆR_36_104, , ORDINÆR_12_104_FANGSTOGFISK, , ORDINÆR_36_104_FANGSTOGFISK, , VERNEPLIKT, ", periode.children.joinToString { it.identifikator + ", " + it.children.joinToString { it.identifikator } })
+        assertEquals(
+            "ORDINÆR_12_52, , ORDINÆR_36_52, , ORDINÆR_12_52_FANGSTOGFISK, , ORDINÆR_36_52_FANGSTOGFISK, , ORDINÆR_12_104, , ORDINÆR_36_104, , ORDINÆR_12_104_FANGSTOGFISK, , ORDINÆR_36_104_FANGSTOGFISK, , VERNEPLIKT, ",
+            periode.children.joinToString { it.identifikator + ", " + it.children.joinToString { it.identifikator } })
     }
 
     @Test
     fun `Ordinær består av ordinær`() {
-        assertEquals("ORDINÆR_12_52, ORDINÆR_36_52, ORDINÆR_12_52_FANGSTOGFISK, ORDINÆR_36_52_FANGSTOGFISK, ORDINÆR_12_104, ORDINÆR_36_104, ORDINÆR_12_104_FANGSTOGFISK, ORDINÆR_36_104_FANGSTOGFISK", ordinær.children.joinToString { it.identifikator })
+        assertEquals(
+            "ORDINÆR_12_52, ORDINÆR_36_52, ORDINÆR_12_52_FANGSTOGFISK, ORDINÆR_36_52_FANGSTOGFISK, ORDINÆR_12_104, ORDINÆR_36_104, ORDINÆR_12_104_FANGSTOGFISK, ORDINÆR_36_104_FANGSTOGFISK",
+            ordinær.children.joinToString { it.identifikator })
     }
 
     @Test
@@ -42,11 +46,12 @@ internal class PeriodeSpesifikasjonerTest {
 
         val rotEvaluering = Evaluering(Resultat.JA, "52", children = evaluering)
         val fakta = Fakta(
-            Inntekt("123", emptyList()), senesteInntektsmåned = YearMonth.of(2019, 4),
+            Inntekt("123", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false,
-            grunnlagBeregningsregel = "bla")
+            grunnlagBeregningsregel = "bla"
+        )
 
         assertEquals(52, finnHøyestePeriodeFraEvaluering(rotEvaluering, fakta))
     }

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeTopologyTest.kt
@@ -33,7 +33,8 @@ internal class PeriodeTopologyTest {
                 )
 
             )
-        )
+        ),
+        sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 2)
     )
 
     companion object {
@@ -177,7 +178,8 @@ internal class PeriodeTopologyTest {
                     )
 
                 )
-            )
+            ),
+            sisteAvsluttendeKalenderMåned = YearMonth.of(2018, 3)
         )
 
         val json = """
@@ -187,7 +189,6 @@ internal class PeriodeTopologyTest {
                 "vedtakId":3.1018297E7,
                 "beregningsDato":"2018-04-06",
                 "harAvtjentVerneplikt":false,
-                "senesteInntektsmåned":"2018-03",
                 "oppfyllerKravTilFangstOgFisk": true,
                 "grunnlagResultat":
                     {
@@ -229,10 +230,13 @@ internal class PeriodeTopologyTest {
             )
         )
 
-        val inntekt = Inntekt(inntektsId = "12345", inntektsListe = emptyList())
+        val inntekt = Inntekt(
+            inntektsId = "12345",
+            inntektsListe = emptyList(),
+            sisteAvsluttendeKalenderMåned = YearMonth.of(2018, 3)
+        )
 
         val packet = Packet()
-        packet.putValue("senesteInntektsmåned", "ERROR")
         packet.putValue("inntektV1", inntekt)
         packet.putValue("grunnlagResultat", "ERROR")
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeTopologyTest.kt
@@ -51,7 +51,7 @@ internal class PeriodeTopologyTest {
     }
 
     @Test
-    fun ` Dagpenger behov without inntekt and "senesteInntektsmåned" should not be processed `() {
+    fun ` Dagpenger behov without inntekt should not be processed `() {
         val periode = Periode(
             Environment(
                 username = "bogus",
@@ -86,7 +86,6 @@ internal class PeriodeTopologyTest {
         )
         val json = """
             {
-            "senesteInntektsmåned":"2019-01"
 
             }
             """.trimIndent()
@@ -124,7 +123,6 @@ internal class PeriodeTopologyTest {
                 "vedtakId":3.1018297E7,
                 "beregningsDato":"2019-02-27",
                 "harAvtjentVerneplikt":false,
-                "senesteInntektsmåned":"2019-01",
                 "grunnlagResultat":
                     {
                         "beregningsregel":"BLA"


### PR DESCRIPTION
…es 'senesteInnteksMåned'

- update to new dapgenger-events version