### PR TITLE
Put nare on packet

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/Periode.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/Periode.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.regel.periode
 
+import com.squareup.moshi.JsonAdapter
 import de.huxhorn.sulky.ulid.ULID
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.Counter
@@ -28,9 +29,12 @@ class Periode(private val env: Environment) : River() {
 
     private val ulidGenerator = ULID()
 
+    val jsonAdapterEvaluering: JsonAdapter<Evaluering> = moshiInstance.adapter(Evaluering::class.java)
+
     companion object {
         val REGELIDENTIFIKATOR = "Periode.v1"
         val PERIODE_RESULTAT = "periodeResultat"
+        val PERIODE_NARE_EVALUERING = "periodeNareEvaluering"
         val INNTEKT = "inntektV1"
         val AVTJENT_VERNEPLIKT = "harAvtjentVerneplikt"
         val FANGST_OG_FISK = "oppfyllerKravTilFangstOgFisk"
@@ -64,6 +68,7 @@ class Periode(private val env: Environment) : River() {
 
         tellHvilkenPeriodeSomBleGitt(periodeResultat)
 
+        packet.putValue(PERIODE_NARE_EVALUERING, jsonAdapterEvaluering.toJson(evaluering))
         packet.putValue(PERIODE_RESULTAT, subsumsjon.toMap())
         return packet
     }

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeTopologyTest.kt
@@ -6,6 +6,7 @@ import no.nav.dagpenger.events.inntekt.v1.InntektKlasse
 import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntekt
 import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntektMåned
 import no.nav.dagpenger.streams.Topics.DAGPENGER_BEHOV_PACKET_EVENT
+import no.nav.nare.core.evaluations.Evaluering
 import org.apache.kafka.streams.StreamsConfig
 import org.apache.kafka.streams.TopologyTestDriver
 import org.apache.kafka.streams.test.ConsumerRecordFactory
@@ -253,6 +254,58 @@ internal class PeriodeTopologyTest {
 
             assertTrue { result.hasField("periodeResultat") }
             assertEquals("52.0", result.getMapValue("periodeResultat")["periodeAntallUker"].toString())
+        }
+    }
+
+    @Test
+    fun ` should add nare evaluation`() {
+        val periode = Periode(
+            Environment(
+                username = "bogus",
+                password = "bogus"
+            )
+        )
+
+        val json = """
+            {
+                "behovId":"01D6V5QCJCH0NQCHF4PZYB0NRJ",
+                "aktørId":"1000052711564",
+                "vedtakId":3.1018297E7,
+                "beregningsDato":"2019-02-27",
+                "harAvtjentVerneplikt":false,
+                "grunnlagResultat":
+                    {
+                        "beregningsregel":"BLA"
+                    },
+                "bruktInntektsPeriode":
+                    {
+                        "førsteMåned":"2016-02",
+                        "sisteMåned":"2016-11"
+                    }
+
+            }
+            """.trimIndent()
+
+        val packet = Packet(json)
+        packet.putValue("inntektV1", inntekt)
+        TopologyTestDriver(periode.buildTopology(), config).use { topologyTestDriver ->
+            val inputRecord = factory.create(packet)
+            topologyTestDriver.pipeInput(inputRecord)
+
+            val ut = topologyTestDriver.readOutput(
+                DAGPENGER_BEHOV_PACKET_EVENT.name,
+                DAGPENGER_BEHOV_PACKET_EVENT.keySerde.deserializer(),
+                DAGPENGER_BEHOV_PACKET_EVENT.valueSerde.deserializer()
+            )
+
+            assertTrue { ut.value().hasField(Periode.PERIODE_NARE_EVALUERING) }
+
+            val nareEvaluering = periode.jsonAdapterEvaluering.fromJson(
+                ut.value().getStringValue(
+                    Periode.PERIODE_NARE_EVALUERING
+            ))
+
+            assertTrue { nareEvaluering is Evaluering }
         }
     }
 


### PR DESCRIPTION
Tester bare at pakken får riktig key med evaluering-objekt, i motsetning til https://github.com/navikt/dp-regel-minsteinntekt/commit/c7c552e1913f0a04a64b6f1e005acba05c274910 hvor jeg faktisk evaluerte i testen for å sjekke at objektene var like. Vet ikke hva som foretrekkes.