### PR TITLE
Fjerner avhenginghet på resultat fra grunnlag

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/Application.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/Application.kt
@@ -45,15 +45,12 @@ class Application(
         val AVTJENT_VERNEPLIKT = "harAvtjentVerneplikt"
         val FANGST_OG_FISK = "oppfyllerKravTilFangstOgFisk"
         val BRUKT_INNTEKTSPERIODE = "bruktInntektsPeriode"
-        val GRUNNLAG_RESULTAT = "grunnlagResultat"
-        val BEREGNINGS_REGEL_GRUNNLAG = "beregningsregel"
         val BEREGNINGSDATO = "beregningsDato"
     }
 
     override fun filterPredicates(): List<Predicate<String, Packet>> {
         return listOf(
             Predicate { _, packet -> packet.hasField(INNTEKT) },
-            Predicate { _, packet -> packet.hasField(GRUNNLAG_RESULTAT) },
             Predicate { _, packet -> packet.hasField(BEREGNINGSDATO) },
             Predicate { _, packet -> !packet.hasField(PERIODE_RESULTAT) })
     }

--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/Fakta.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/Fakta.kt
@@ -21,7 +21,6 @@ data class Fakta(
         isThisGjusteringTest(beregningsDato) -> Grunnbeløp.GjusteringsTest.verdi
         else -> getGrunnbeløpForRegel(Regel.Minsteinntekt).forDato(beregningsDato).verdi
     },
-    val grunnlagBeregningsregel: String,
     val lærling: Boolean
 ) {
     val filtrertInntekt = bruktInntektsPeriode?.let { inntektsPeriode ->

--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/LøsningService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/LøsningService.kt
@@ -5,10 +5,6 @@ import de.huxhorn.sulky.ulid.ULID
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import mu.withLoggingContext
-import no.nav.dagpenger.events.inntekt.v1.Inntekt
-import no.nav.dagpenger.events.inntekt.v1.InntektKlasse
-import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntekt
-import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntektMåned
 import no.nav.dagpenger.inntekt.rpc.InntektHenter
 import no.nav.dagpenger.regel.periode.Application.Companion.AVTJENT_VERNEPLIKT
 import no.nav.dagpenger.regel.periode.Application.Companion.BRUKT_INNTEKTSPERIODE
@@ -21,7 +17,6 @@ import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.asLocalDate
 import no.nav.helse.rapids_rivers.asYearMonth
 import no.nav.nare.core.evaluations.Evaluering
-import java.math.BigDecimal
 
 class LøsningService(
     rapidsConnection: RapidsConnection,
@@ -96,21 +91,3 @@ private fun JsonMessage.toFakta(inntektHenter: InntektHenter): Fakta = Fakta(
     beregningsDato = this["beregningsdato"].asLocalDate(),
     lærling = this[LÆRLING].asBoolean(false)
 )
-
-private fun JsonNode.asInntekt() = Inntekt(
-    inntektsId = this["inntektsId"].asText(),
-    inntektsListe = this["inntektsListe"].map { it.asKlassifisertInntektMåned() },
-    manueltRedigert = this["manueltRedigert"].asBoolean(false),
-    sisteAvsluttendeKalenderMåned = this["sisteAvsluttendeKalenderMåned"].asYearMonth()
-)
-
-private fun JsonNode.asKlassifisertInntektMåned() =
-    KlassifisertInntektMåned(
-        årMåned = this["årMåned"].asYearMonth(),
-        klassifiserteInntekter = this["klassifiserteInntekter"].map {
-            KlassifisertInntekt(
-                beløp = BigDecimal(
-                    it["beløp"].asInt()
-                ), inntektKlasse = InntektKlasse.valueOf(it["inntektKlasse"].asText())
-            )
-        })

--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/LøsningService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/LøsningService.kt
@@ -2,7 +2,6 @@ package no.nav.dagpenger.regel.periode
 
 import com.fasterxml.jackson.databind.JsonNode
 import de.huxhorn.sulky.ulid.ULID
-import java.math.BigDecimal
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import mu.withLoggingContext
@@ -12,10 +11,8 @@ import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntekt
 import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntektMåned
 import no.nav.dagpenger.inntekt.rpc.InntektHenter
 import no.nav.dagpenger.regel.periode.Application.Companion.AVTJENT_VERNEPLIKT
-import no.nav.dagpenger.regel.periode.Application.Companion.BEREGNINGS_REGEL_GRUNNLAG
 import no.nav.dagpenger.regel.periode.Application.Companion.BRUKT_INNTEKTSPERIODE
 import no.nav.dagpenger.regel.periode.Application.Companion.FANGST_OG_FISK
-import no.nav.dagpenger.regel.periode.Application.Companion.GRUNNLAG_RESULTAT
 import no.nav.dagpenger.regel.periode.Application.Companion.LÆRLING
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageProblems
@@ -24,6 +21,7 @@ import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.asLocalDate
 import no.nav.helse.rapids_rivers.asYearMonth
 import no.nav.nare.core.evaluations.Evaluering
+import java.math.BigDecimal
 
 class LøsningService(
     rapidsConnection: RapidsConnection,
@@ -39,14 +37,19 @@ class LøsningService(
             validate {
                 it.requireKey(
                     "@id",
-                    GRUNNLAG_RESULTAT,
-                    BRUKT_INNTEKTSPERIODE,
                     "beregningsdato",
                     "vedtakId",
                     "inntektId"
                 )
             }
-            validate { it.interestedIn(AVTJENT_VERNEPLIKT, FANGST_OG_FISK, LÆRLING) }
+            validate {
+                it.interestedIn(
+                    AVTJENT_VERNEPLIKT,
+                    BRUKT_INNTEKTSPERIODE,
+                    FANGST_OG_FISK,
+                    LÆRLING
+                )
+            }
         }.register(this)
     }
 
@@ -90,7 +93,6 @@ private fun JsonMessage.toFakta(inntektHenter: InntektHenter): Fakta = Fakta(
     },
     verneplikt = this[AVTJENT_VERNEPLIKT].asBoolean(false),
     fangstOgFisk = this[FANGST_OG_FISK].asBoolean(false),
-    grunnlagBeregningsregel = this[GRUNNLAG_RESULTAT][BEREGNINGS_REGEL_GRUNNLAG].asText(),
     beregningsDato = this["beregningsdato"].asLocalDate(),
     lærling = this[LÆRLING].asBoolean(false)
 )

--- a/src/main/kotlin/no/nav/dagpenger/regel/periode/PacketToFakta.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/periode/PacketToFakta.kt
@@ -19,15 +19,11 @@ internal fun packetToFakta(packet: Packet): Fakta {
 
     val fangstOgFisk = packet.getNullableBoolean(Application.FANGST_OG_FISK) ?: false
 
-    val grunnlagBeregningsregel =
-        packet.getMapValue(Application.GRUNNLAG_RESULTAT)[Application.BEREGNINGS_REGEL_GRUNNLAG].toString()
-
     return Fakta(
         inntekt = inntekt,
         bruktInntektsPeriode = bruktInntektsPeriode,
         verneplikt = verneplikt,
         fangstOgFisk = fangstOgFisk,
-        grunnlagBeregningsregel = grunnlagBeregningsregel,
         beregningsDato = beregningsDato,
         lærling = lærling
     )

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/ApplicationTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/ApplicationTopologyTest.kt
@@ -74,41 +74,9 @@ internal class ApplicationTopologyTest {
     }
 
     @Test
-    fun ` Dagpenger behov without grunnlagResultat should not be processed `() {
-        val json = """
-            {
-                "beregningsDato": "2019-05-20"
-            }
-            """.trimIndent()
-
-        val packet = Packet(json)
-        packet.putValue("inntektV1", inntekt)
-
-        TopologyTestDriver(periode.buildTopology(), config).use { topologyTestDriver ->
-            val inputRecord = factory.create(packet)
-            topologyTestDriver.pipeInput(inputRecord)
-
-            val ut = topologyTestDriver.readOutput(
-                DAGPENGER_BEHOV_PACKET_EVENT.name,
-                DAGPENGER_BEHOV_PACKET_EVENT.keySerde.deserializer(),
-                DAGPENGER_BEHOV_PACKET_EVENT.valueSerde.deserializer()
-            )
-
-            assertTrue { null == ut }
-        }
-    }
-
-    @Test
     fun ` dagpengebehov without beregningsDato should not be processed`() {
 
-        val emptyjsonBehov = """
-            {
-                "grunnlagResultat":
-                    {
-                        "beregningsregel":"BLA"
-                    }
-            }
-            """.trimIndent()
+        val emptyjsonBehov = "{}"
 
         val packet = Packet(emptyjsonBehov)
         packet.putValue("inntektV1", inntekt)
@@ -136,10 +104,6 @@ internal class ApplicationTopologyTest {
                 "vedtakId":3.1018297E7,
                 "beregningsDato":"2019-02-27",
                 "harAvtjentVerneplikt":false,
-                "grunnlagResultat":
-                    {
-                        "beregningsregel":"BLA"
-                    },
                 "bruktInntektsPeriode":
                     {
                         "førsteMåned":"2016-02",
@@ -195,10 +159,6 @@ internal class ApplicationTopologyTest {
                 "beregningsDato":"2018-04-06",
                 "harAvtjentVerneplikt":false,
                 "oppfyllerKravTilFangstOgFisk": true,
-                "grunnlagResultat":
-                    {
-                        "beregningsregel":"BLA"
-                    },
                 "bruktInntektsPeriode":
                     {
                         "førsteMåned":"2016-02",
@@ -236,10 +196,6 @@ internal class ApplicationTopologyTest {
                 "vedtakId":3.1018297E7,
                 "beregningsDato":"2019-02-27",
                 "harAvtjentVerneplikt":false,
-                "grunnlagResultat":
-                    {
-                        "beregningsregel":"BLA"
-                    },
                 "bruktInntektsPeriode":
                     {
                         "førsteMåned":"2016-02",
@@ -266,7 +222,8 @@ internal class ApplicationTopologyTest {
             val nareEvaluering = periode.jsonAdapterEvaluering.fromJson(
                 ut.value().getStringValue(
                     Application.PERIODE_NARE_EVALUERING
-                ))
+                )
+            )
 
             assertTrue { nareEvaluering is Evaluering }
         }
@@ -287,8 +244,7 @@ internal class ApplicationTopologyTest {
             """.trimIndent()
 
         val packet = Packet(json)
-        packet.putValue("inntektV1", inntekt)
-        packet.putValue("grunnlagResultat", "ERROR")
+        packet.putValue("inntektV1", "ERROR")
 
         TopologyTestDriver(periode.buildTopology(), config).use { topologyTestDriver ->
             val inputRecord = factory.create(packet)

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
@@ -81,7 +81,7 @@ class FinnerRettPeriodeTest {
     }
 
     @Test
-    fun ` Skal returnere 104 uker periode dersom kravet til verneplikt er oppfylt og har tjent mer enn 2G `() {
+    fun ` Skal returnere 104 uker periode dersom kravet til verneplikt ikke er oppfylt og har tjent mer enn 2G `() {
 
         val inntektsListe = generateArbeidsInntekt(1..12, BigDecimal(30000))
         val fakta = Fakta(

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
@@ -140,7 +140,7 @@ class FinnerRettPeriodeTest {
     }
 
     @Test
-    fun ` Skal returnere 52 uker periode dersom kravet til verneplikt er oppfylt og har minus i inntektsum `() {
+    fun ` Skal returnere 52 uker periode dersom kravet til verneplikt ikke er oppfylt og har minus i inntektsum `() {
         val fakta = Fakta(
             inntekt = Inntekt(
                 "123",

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
@@ -59,7 +59,7 @@ class FinnerRettPeriodeTest {
     }
 
     @Test
-    fun ` Skal returnere 52 uker periode dersom kravet til verneplikt er oppfylt og har tjent mindre enn 2G `() {
+    fun ` Skal returnere 52 uker periode dersom kravet til verneplikt ikke er oppfylt og har tjent mindre enn 2G `() {
 
         val inntektsListe = generateArbeidsInntekt(1..12, BigDecimal(3000))
         val fakta = Fakta(

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
@@ -103,7 +103,7 @@ class FinnerRettPeriodeTest {
     }
 
     @Test
-    fun ` Skal returnere 52 uker periode dersom kravet til verneplikt er oppfylt og har tjent mindre enn 2G pga minusinntekt `() {
+    fun ` Skal returnere 52 uker periode dersom kravet til verneplikt ikke er oppfylt og har tjent mindre enn 2G pga minusinntekt `() {
         val inntekt = listOf(
             KlassifisertInntektMåned(
                 YearMonth.of(2019, 3), klassifiserteInntekter = listOf(

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/FinnerRettPeriodeTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 class FinnerRettPeriodeTest {
 
     @Test
-    fun ` Skal returnere 26 uker periode dersom beregningsregelen fra grunnlag er verneplikt `() {
+    fun ` Skal returnere 26 uker periode dersom kravet til verneplikt er oppfylt`() {
 
         val inntektsListe = generateArbeidsInntekt(
             1..12, BigDecimal(3000)
@@ -28,7 +28,6 @@ class FinnerRettPeriodeTest {
             verneplikt = true,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "Verneplikt",
             lærling = false
         )
 
@@ -38,7 +37,7 @@ class FinnerRettPeriodeTest {
     }
 
     @Test
-    fun ` Skal returnere 26 uker periode dersom beregningsregelen fra grunnlag er verneplikt og har minus i inntektsum `() {
+    fun ` Skal returnere 26 uker periode dersom kravet til verneplikt er oppfylt og har minus i inntektsum `() {
         val fakta = Fakta(
             inntekt = Inntekt(
                 "123",
@@ -49,7 +48,6 @@ class FinnerRettPeriodeTest {
             verneplikt = true,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "Verneplikt",
             lærling = false
         )
 
@@ -61,7 +59,7 @@ class FinnerRettPeriodeTest {
     }
 
     @Test
-    fun ` Skal returnere 52 uker periode dersom beregningsregelen fra grunnlag ikke er verneplikt og har tjent mindre enn 2G `() {
+    fun ` Skal returnere 52 uker periode dersom kravet til verneplikt er oppfylt og har tjent mindre enn 2G `() {
 
         val inntektsListe = generateArbeidsInntekt(1..12, BigDecimal(3000))
         val fakta = Fakta(
@@ -74,7 +72,6 @@ class FinnerRettPeriodeTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "BLA",
             lærling = false
         )
 
@@ -84,7 +81,7 @@ class FinnerRettPeriodeTest {
     }
 
     @Test
-    fun ` Skal returnere 104 uker periode dersom beregningsregelen fra grunnlag ikke er verneplikt og har tjent mer enn 2G `() {
+    fun ` Skal returnere 104 uker periode dersom kravet til verneplikt er oppfylt og har tjent mer enn 2G `() {
 
         val inntektsListe = generateArbeidsInntekt(1..12, BigDecimal(30000))
         val fakta = Fakta(
@@ -97,7 +94,6 @@ class FinnerRettPeriodeTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "BLA",
             lærling = false
         )
 
@@ -107,7 +103,7 @@ class FinnerRettPeriodeTest {
     }
 
     @Test
-    fun ` Skal returnere 52 uker periode dersom beregningsregelen fra grunnlag ikke er verneplikt og har tjent mindre enn 2G pga minusinntekt `() {
+    fun ` Skal returnere 52 uker periode dersom kravet til verneplikt er oppfylt og har tjent mindre enn 2G pga minusinntekt `() {
         val inntekt = listOf(
             KlassifisertInntektMåned(
                 YearMonth.of(2019, 3), klassifiserteInntekter = listOf(
@@ -133,7 +129,6 @@ class FinnerRettPeriodeTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "BLA",
             lærling = false
         )
 
@@ -145,7 +140,7 @@ class FinnerRettPeriodeTest {
     }
 
     @Test
-    fun ` Skal returnere 52 uker periode dersom beregningsregelen fra grunnlag ikke er verneplikt og har minus i inntektsum `() {
+    fun ` Skal returnere 52 uker periode dersom kravet til verneplikt er oppfylt og har minus i inntektsum `() {
         val fakta = Fakta(
             inntekt = Inntekt(
                 "123",
@@ -156,7 +151,6 @@ class FinnerRettPeriodeTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "BLA",
             lærling = false
         )
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/GjusteringTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/GjusteringTest.kt
@@ -34,7 +34,6 @@ internal class GjusteringTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 10, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -56,7 +55,6 @@ internal class GjusteringTest {
                 verneplikt = false,
                 fangstOgFisk = false,
                 beregningsDato = LocalDate.of(2019, 10, 20),
-                grunnlagBeregningsregel = "bla",
                 lærling = false
             )
 
@@ -70,10 +68,10 @@ internal class GjusteringTest {
         return (range).toList().map {
             KlassifisertInntektMåned(
                 YearMonth.of(2019, 1).minusMonths(it.toLong()), listOf(
-                KlassifisertInntekt(
-                    beløpPerMnd, InntektKlasse.ARBEIDSINNTEKT
+                    KlassifisertInntekt(
+                        beløpPerMnd, InntektKlasse.ARBEIDSINNTEKT
+                    )
                 )
-            )
             )
         }
     }

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/LøsningServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/LøsningServiceTest.kt
@@ -68,9 +68,6 @@ internal class LøsningServiceTest {
               ],
               "@id": "123",
               "beregningsdato": "2020-04-01",
-              "grunnlagResultat": {
-                "beregningsregel": "ORDINAER"
-              },
               "bruktInntektsPeriode": {
                 "førsteMåned": "2019-12",
                 "sisteMåned": "2020-04"

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PacketToFaktaTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PacketToFaktaTest.kt
@@ -22,7 +22,6 @@ class PacketToFaktaTest {
     fun ` should map fangst_og_fisk from packet to Fakta `() {
         val json = """
         {
-            "grunnlagResultat":{"beregningsregel": "test"},
             "oppfyllerKravTilFangstOgFisk": true,
             "beregningsDato": "2019-05-20"
         }""".trimIndent()
@@ -39,7 +38,6 @@ class PacketToFaktaTest {
     fun ` should map avtjent_verneplikt from packet to Fakta `() {
         val json = """
         {
-            "grunnlagResultat":{"beregningsregel": "test"},
             "harAvtjentVerneplikt": true,
             "beregningsDato": "2019-05-20"
         }""".trimIndent()
@@ -56,7 +54,6 @@ class PacketToFaktaTest {
     fun ` should map beregningsdato from packet to Fakta `() {
         val json = """
         {
-            "grunnlagResultat":{"beregningsregel": "test"},
             "harAvtjentVerneplikt": true,
             "beregningsDato": "2019-05-20"
         }""".trimIndent()
@@ -73,7 +70,6 @@ class PacketToFaktaTest {
     fun ` should get correct grunnbelop before new G`() {
         val json = """
         {
-            "grunnlagResultat":{"beregningsregel": "test"},
             "harAvtjentVerneplikt": true,
             "beregningsDato": "2019-05-20"
         }""".trimIndent()
@@ -90,7 +86,6 @@ class PacketToFaktaTest {
     fun ` should get correct grunnbelop after new G`() {
         val json = """
         {
-            "grunnlagResultat":{"beregningsregel": "test"},
             "harAvtjentVerneplikt": true,
             "beregningsDato": "2019-05-27"
         }""".trimIndent()
@@ -107,7 +102,6 @@ class PacketToFaktaTest {
     fun ` should map brukt_inntektsperiode from packet to Fakta `() {
         val json = """
         {
-            "grunnlagResultat":{"beregningsregel": "test"},
             "bruktInntektsPeriode": {"førsteMåned":"2019-02", "sisteMåned":"2019-03"},
             "beregningsDato": "2019-05-20"
         }""".trimIndent()
@@ -125,7 +119,6 @@ class PacketToFaktaTest {
     fun ` should map inntekt from packet to Fakta `() {
         val json = """
         {
-            "grunnlagResultat":{"beregningsregel": "test"},
             "beregningsDato": "2019-05-20"
         }""".trimIndent()
 
@@ -138,26 +131,9 @@ class PacketToFaktaTest {
     }
 
     @Test
-    fun ` should map grunnlag_beregningsregel from packet to Fakta `() {
-        val json = """
-        {
-            "grunnlagResultat":{"beregningsregel": "regel"},
-            "beregningsDato": "2019-05-20"
-        }""".trimIndent()
-
-        val packet = Packet(json)
-        packet.putValue("inntektV1", jsonAdapterInntekt.toJsonValue(emptyInntekt)!!)
-
-        val fakta = packetToFakta(packet)
-
-        assertEquals("regel", fakta.grunnlagBeregningsregel)
-    }
-
-    @Test
     fun ` should map lærling from packet to Fakta `() {
         val json = """
         {
-            "grunnlagResultat":{"beregningsregel": "regel"},
             "beregningsDato": "2019-05-20",
             "lærling": "true"
         }""".trimIndent()

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/Periode104UkerTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/Periode104UkerTest.kt
@@ -26,7 +26,6 @@ internal class Periode104UkerTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -48,7 +47,6 @@ internal class Periode104UkerTest {
             verneplikt = false,
             fangstOgFisk = true,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -70,7 +68,6 @@ internal class Periode104UkerTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -92,7 +89,6 @@ internal class Periode104UkerTest {
             verneplikt = false,
             fangstOgFisk = true,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -115,7 +111,6 @@ internal class Periode104UkerTest {
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(13),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -138,7 +133,6 @@ internal class Periode104UkerTest {
             fangstOgFisk = true,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(13),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -161,7 +155,6 @@ internal class Periode104UkerTest {
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(6),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -184,7 +177,6 @@ internal class Periode104UkerTest {
             fangstOgFisk = true,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(6),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -207,7 +199,6 @@ internal class Periode104UkerTest {
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(13),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -230,7 +221,6 @@ internal class Periode104UkerTest {
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(13),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/Periode52UkerTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/Periode52UkerTest.kt
@@ -26,7 +26,6 @@ internal class Periode52UkerTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -48,7 +47,6 @@ internal class Periode52UkerTest {
             verneplikt = false,
             fangstOgFisk = true,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -70,7 +68,6 @@ internal class Periode52UkerTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -92,7 +89,6 @@ internal class Periode52UkerTest {
             verneplikt = false,
             fangstOgFisk = true,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -115,7 +111,6 @@ internal class Periode52UkerTest {
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(13),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -138,7 +133,6 @@ internal class Periode52UkerTest {
             fangstOgFisk = true,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(13),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -161,7 +155,6 @@ internal class Periode52UkerTest {
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(37),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -184,7 +177,6 @@ internal class Periode52UkerTest {
             fangstOgFisk = true,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(37),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -207,7 +199,6 @@ internal class Periode52UkerTest {
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(13),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -230,7 +221,6 @@ internal class Periode52UkerTest {
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
             grunnbeløp = BigDecimal(13),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeEtterAvtjentVernepliktTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeEtterAvtjentVernepliktTest.kt
@@ -19,7 +19,6 @@ internal class PeriodeEtterAvtjentVernepliktTest {
             verneplikt = true,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -40,7 +39,6 @@ internal class PeriodeEtterAvtjentVernepliktTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeEtterLærlingForskriftTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeEtterLærlingForskriftTest.kt
@@ -19,7 +19,6 @@ internal class PeriodeEtterLærlingForskriftTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2020, 3, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = true
         )
 
@@ -41,7 +40,6 @@ internal class PeriodeEtterLærlingForskriftTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2020, 4, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -62,7 +60,6 @@ internal class PeriodeEtterLærlingForskriftTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2021, 1, 1),
-            grunnlagBeregningsregel = "bla",
             lærling = true
         )
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeSpesifikasjonTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/periode/PeriodeSpesifikasjonTest.kt
@@ -18,7 +18,9 @@ import org.junit.jupiter.api.Test
 
 internal class PeriodeSpesifikasjonTest {
 
-    fun identifikatorer(spesifikasjoner: List<Spesifikasjon<Fakta>>): Set<String> = (spesifikasjoner.map { it.identifikator }.toSet() + spesifikasjoner.flatMap { identifikatorer(it.children) }).toSet()
+    fun identifikatorer(spesifikasjoner: List<Spesifikasjon<Fakta>>): Set<String> =
+        (spesifikasjoner.map { it.identifikator }
+            .toSet() + spesifikasjoner.flatMap { identifikatorer(it.children) }).toSet()
 
     @Test
     fun `Ordinær består av ordinær`() {
@@ -75,7 +77,6 @@ internal class PeriodeSpesifikasjonTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2019, 5, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
 
@@ -94,7 +95,6 @@ internal class PeriodeSpesifikasjonTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2020, 3, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = true
         )
         val evaluering = periode.evaluer(fakta)
@@ -118,7 +118,6 @@ internal class PeriodeSpesifikasjonTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2020, 3, 1),
-            grunnlagBeregningsregel = "bla",
             lærling = true
         )
 
@@ -143,7 +142,6 @@ internal class PeriodeSpesifikasjonTest {
             verneplikt = true,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2020, 3, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
         val evaluering = periode.evaluer(fakta)
@@ -167,7 +165,6 @@ internal class PeriodeSpesifikasjonTest {
             verneplikt = false,
             fangstOgFisk = false,
             beregningsDato = LocalDate.of(2020, 3, 20),
-            grunnlagBeregningsregel = "bla",
             lærling = false
         )
         val evaluering = periode.evaluer(fakta)


### PR DESCRIPTION
Det er noen spor etter at vi i gamle dager brukte beregningsregelen for å fastsette periode, men at det nå ser ut som man tar utgangspunkt i de eksplisitte flaggene satt for verneplikt/lærling/ff.